### PR TITLE
Limit unauthenticated /api/users access to POST requests

### DIFF
--- a/src/main/java/com/supemir/association/config/SecurityConfig.java
+++ b/src/main/java/com/supemir/association/config/SecurityConfig.java
@@ -13,6 +13,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.http.HttpMethod;
 
 import java.util.Arrays;
 import java.util.List;
@@ -33,7 +34,7 @@ public class SecurityConfig {
                 .cors(Customizer.withDefaults())
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/users").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/users").permitAll()
                         .requestMatchers("/api/actuator/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/api/**").authenticated()


### PR DESCRIPTION
## Summary
- only allow unauthenticated POST requests to `/api/users`
- import `HttpMethod`

## Testing
- `mvnw test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6873c1186d248331a218538f121134c6