### PR TITLE
Fix comment regarding enum constraints

### DIFF
--- a/src/main/resources/db/migration/V1__init_schema.sql
+++ b/src/main/resources/db/migration/V1__init_schema.sql
@@ -56,7 +56,7 @@ CREATE TABLE journal (
     id_utilisateur INTEGER NOT NULL REFERENCES utilisateur(id)
 );
 
--- Optional: add CHECK constraints for enums
+-- Add CHECK constraints for enums
 ALTER TABLE utilisateur
   ADD CONSTRAINT chk_role CHECK (role IN ('ADMIN','USER'));
 


### PR DESCRIPTION
## Summary
- update the SQL migration comment about enum constraints

## Testing
- `./mvnw -q test` *(fails: failed to fetch Maven due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6873c1161e508331b0a59f1c37f8ac3a