### PR TITLE
Restrict user endpoint access

### DIFF
--- a/src/main/java/com/supemir/association/config/SecurityConfig.java
+++ b/src/main/java/com/supemir/association/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -33,7 +34,7 @@ public class SecurityConfig {
                 .cors(Customizer.withDefaults())
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/users").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/users").permitAll()
                         .requestMatchers("/api/actuator/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/api/**").authenticated()


### PR DESCRIPTION
## Summary
- allow anonymous POST requests on `/api/users` endpoint instead of all HTTP methods
- add `HttpMethod` import for clarity

## Testing
- `mvnw -q test` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6873c06e27448331a8638fb824f39790